### PR TITLE
Lorenz96でのデータ同化実装とv1のリファクタリング

### DIFF
--- a/lorenz63_main.f90
+++ b/lorenz63_main.f90
@@ -6,6 +6,7 @@ program lorenz63
   use common
   use common_mtx
   use lorenz63_prm
+  use lorenz63_cal
 
   implicit none
 
@@ -51,7 +52,10 @@ program lorenz63
   real(r_size), allocatable :: Kg(:,:)  ! Kalman gain
   real(r_size), allocatable :: Kh(:,:)  ! Kalman gain for pertuvation
   real(r_size), allocatable ::  H(:,:)  ! Observation operator
-  real(r_size), allocatable :: Pr(:,:)
+
+  real(r_size), allocatable :: hx(:,:)
+  real(r_size), allocatable :: hdxf(:,:)
+  real(r_size), allocatable :: work(:)
 
   real(r_size), allocatable :: obs_mtx(:,:)
   real(r_size), allocatable :: obs_inv(:,:)
@@ -59,10 +63,6 @@ program lorenz63
   ! --- for EnSRF
   real(r_size), allocatable :: obs_srf_mtx_v1(:,:), obs_srf_mtx_v2(:,:)
   real(r_size), allocatable :: obs_srf_inv_v1(:,:), obs_srf_inv_v2(:,:)
-
-  real(r_size), allocatable :: hx(:,:)
-  real(r_size), allocatable :: hdxf(:,:)
-  real(r_size), allocatable :: work(:)
   
   ! --- Output control
   logical                   :: opt_veach = .false.
@@ -151,7 +151,6 @@ program lorenz63
   allocate(Kh(1:nx, 1:ny))
   allocate( H(1:ny, 1:nx))
   allocate( R(1:ny, 1:ny))
-  allocate(Pr(1:ny, 1:ny))
 
   allocate(obs_mtx(1:ny, 1:ny), obs_inv(1:ny, 1:ny))
   allocate(obs_srf_mtx_v1(1:ny, 1:ny), obs_srf_mtx_v2(1:ny, 1:ny))
@@ -311,7 +310,7 @@ program lorenz63
         write(6,*) '  TRUTH    = ', x_true(it), y_true(it), z_true(it)
         write(6,*) '  PREDICT  = ', x_sim(it), y_sim(it), z_sim(it)
         write(6,*) '  OBSERVE  = ', x_obs(it/obs_interval), y_obs(it/obs_interval), z_obs(it/obs_interval)
-        write(6,*) '  ANALYSIS = ', x_anl(it), y_anl(it), z_anl(it)
+        write(6,*) '  ANALYSIS (BEFORE) = ', x_anl(it), y_anl(it), z_anl(it)
         write(6,*) ''
 
         !--------------------------------------------------------------------------------
@@ -327,7 +326,7 @@ program lorenz63
         !)
         ! +++ for check
         ! write(6,*) x_trend, y_trend, z_trend
-        
+        !
         ! >> Jacobian　matrix (*** origin form)
         !JM(1,1) = -sig              ;JM(1,2) = sig             ;JM(1,3) = 0.0d0
         !JM(2,1) = gamm -z_anl(it-1) ;JM(2,2) = -1.d0           ;JM(2,3) = -x_anl(it-1)
@@ -390,7 +389,8 @@ program lorenz63
         
         xt_vec = xt_vec + matmul(Kg, hdxf)
         x_anl(it) = xt_vec(1,1); y_anl(it) = xt_vec(2,1); z_anl(it) = xt_vec(3,1)
-        
+        write(6,*) '  ANALYSIS (AFTER) = ', x_anl(it), y_anl(it), z_anl(it)
+        write(6,*) ''
         ! >> 4.2.5 analysis error covariance matrix
         Pa = matmul(I - matmul(Kg, H), Pf)
       end if

--- a/lorenz63_view.py
+++ b/lorenz63_view.py
@@ -162,7 +162,7 @@ class lorenz63_score:
     ax1.set_ylabel('RMSE')
     ax1.set_xlim(0, 1)
     ax1.set_ylim(0, 10)
-    ax1.set_title('Lorenz(1963) RMSE infla. ***', loc='left')
+    ax1.set_title('Lorenz(1963) RMSE infla. 0.0d0', loc='left')
 
     plt.grid()
     plt.legend()

--- a/lorenz96_compiler.sh
+++ b/lorenz96_compiler.sh
@@ -3,7 +3,7 @@
 
 set -ex
 CDIR=`pwd`
-tool='normal' #spinup or normal
+tool='spinup' #spinup or normal
 ts_check='true' # if spinup output is 'true' or 'sim'.
 prg=lorenz96_${tool}_maintools
 today=$(date "+%Y%m%d%H%M")
@@ -57,7 +57,7 @@ cp ${CDIR}/common/netlib.f netlib_mod.f
 
 # +++ compile
 gfortran -fbounds-check  \
-  SFMT_mod.f90 common_mod.f90 common_mtx_mod.f90 lorenz96_prm.f90 lorenz96_cal.f90 lorenz96_main.f90 \
+  SFMT_mod.f90 common_mod.f90 netlib_mod.f common_mtx_mod.f90 lorenz96_prm.f90 lorenz96_cal.f90 lorenz96_main.f90 \
   -o ${prg} -I/usr/local/include -lm -lblas -llapack \
   -w # error message Suppression
 

--- a/lorenz96_compiler.sh
+++ b/lorenz96_compiler.sh
@@ -28,8 +28,8 @@ intg_method='Runge-Kutta'
 mem=1
 enkf_method='none'
 if [ ${da_method} = 'EnKF' ]; then 
-  mem=500
-  enkf_method='PO' # 'PO' or "SRF"
+  mem=50
+  enkf_method='SRF' # 'PO' or "SRF"
 fi
 
 # +++ adaptive inflation

--- a/lorenz96_compiler.sh
+++ b/lorenz96_compiler.sh
@@ -3,7 +3,7 @@
 
 set -ex
 CDIR=`pwd`
-tool='spinup' #spinup or normal
+tool='normal' #spinup or normal
 ts_check='true' # if spinup output is 'true' or 'sim'.
 prg=lorenz96_${tool}_maintools
 today=$(date "+%Y%m%d%H%M")
@@ -12,6 +12,8 @@ rm -rf *.mod ${prg}
 #----------------------------------------------------------------------
 # +++ Set intial setting
 #----------------------------------------------------------------------
+
+# +++ model dimension
 nx=40
 dt=0.05d0
 force=8.0d0
@@ -21,9 +23,14 @@ oneday=0.2d0
 spinup_period=365
 normal_period=40
 
-da_method='KF'
+da_method='EnKF'
 intg_method='Runge-Kutta'
-mem=40
+mem=1
+enkf_method='none'
+if [ ${da_method} = 'EnKF' ]; then 
+  mem=5
+  enkf_method='PO' # 'PO' or "SRF"
+fi
 
 # +++ adaptive inflation
 alpha=0.0d0
@@ -78,6 +85,10 @@ gfortran -fbounds-check  \
     mems      = ${mem},
     da_method = '${da_method}',
     alpha = ${alpha}
+  /
+  &enkf_setting
+    mems = ${mem},
+    enkf_method = '${enkf_method}'
   /
   &set_period
     spinup_period = ${spinup_period},

--- a/lorenz96_compiler.sh
+++ b/lorenz96_compiler.sh
@@ -28,7 +28,7 @@ intg_method='Runge-Kutta'
 mem=1
 enkf_method='none'
 if [ ${da_method} = 'EnKF' ]; then 
-  mem=5
+  mem=5000
   enkf_method='PO' # 'PO' or "SRF"
 fi
 

--- a/lorenz96_compiler.sh
+++ b/lorenz96_compiler.sh
@@ -28,7 +28,7 @@ intg_method='Runge-Kutta'
 mem=1
 enkf_method='none'
 if [ ${da_method} = 'EnKF' ]; then 
-  mem=15
+  mem=500
   enkf_method='PO' # 'PO' or "SRF"
 fi
 
@@ -37,7 +37,7 @@ alpha=0.0d0
 
 # +++ making obs. info
 obs_xintv=1
-obs_tintv=2
+obs_tintv=1
 
 # +++ output info
 out_boolen='true' # write putput

--- a/lorenz96_compiler.sh
+++ b/lorenz96_compiler.sh
@@ -28,7 +28,7 @@ intg_method='Runge-Kutta'
 mem=1
 enkf_method='none'
 if [ ${da_method} = 'EnKF' ]; then 
-  mem=5000
+  mem=15
   enkf_method='PO' # 'PO' or "SRF"
 fi
 

--- a/lorenz96_main.f90
+++ b/lorenz96_main.f90
@@ -314,7 +314,11 @@ program lorenz96_main
           !-----------------------------------------------------------
           ! +++ inflation mode
           !-----------------------------------------------------------
+          write(6,*) ' KALMAN GAIN WEIGHTING MATRIX '
           Kg = matmul(matmul(Pf, transpose(H)), obs_inv)
+          call confirm_matrix(Kg, nx, ny)
+          write(6,*) ''
+
           x_anl(it,:) = x_anl(it,:) + matmul(Kg, (x_obs(it/obs_tintv,:) - matmul(H, x_anl(it,:))))
           write(6,*) '  ANALYSIS (AFTER) = ', x_anl(it,:)
           
@@ -367,7 +371,7 @@ program lorenz96_main
           !------------------------------------------------------- 
           do imem = 1, mems
             x_prtb(:,imem) = x_anl_m(it,:,imem) - x_anl(it,:)
-            Ef(:,imem) = x_prtb(:,imem)
+            Ef(:,imem) = x_prtb(:,imem)/sqrt(float(mems-1))
           end do
 
           write(6,*) ' PREDICTION ENSEMBLE VECTOR '
@@ -391,7 +395,10 @@ program lorenz96_main
           ! +++ adaptive inflation mode
           !-----------------------------------------------------------
           Pf = Pf*(1.0d0 + alpha)
+          write(6,*) ' KALMAN GAIN WEIGHTING MATRIX '
           Kg = matmul(matmul(Pf, transpose(H)), obs_inv)
+          call confirm_matrix(Kg, nx, ny)
+          write(6,*) ''
           
           da_enkf_method :&
           if ( trim(enkf_method) == 'PO' ) then
@@ -415,7 +422,7 @@ program lorenz96_main
               
               hdxf = yt_vec - hx
               xt_vec = xt_vec + matmul(Kg, hdxf)
-              
+
               x_anl_m(it,:,imem) =  xt_vec(:,1)
             end do
 

--- a/lorenz96_main.f90
+++ b/lorenz96_main.f90
@@ -264,10 +264,10 @@ program lorenz96_main
         call ting_rk4(one_loop, x_anl(it-1,:), x_anl(it,:))
         
         if ( mod(it, obs_tintv)==0 ) then
-          write(6,*) '  TRUTH    = ', x_true(it,1:5)
-          write(6,*) '  PREDICT  = ', x_sim(it,1:5)
-          write(6,*) '  OBSERVE  = ', x_obs(it,1:5)
-          write(6,*) '  ANALYSIS (BEFORE) = ', x_anl(it,1:5)
+          write(6,*) '  TRUTH    = ', x_true(it,1:5), '...'
+          write(6,*) '  PREDICT  = ', x_sim(it,1:5), '...'
+          write(6,*) '  OBSERVE  = ', x_obs(it,1:5), '...'
+          write(6,*) '  ANALYSIS (BEFORE) = ', x_anl(it,1:5), '...'
           write(6,*) ''
           
           !-------------------------------------------------------------------
@@ -320,7 +320,7 @@ program lorenz96_main
           write(6,*) ''
 
           x_anl(it,:) = x_anl(it,:) + matmul(Kg, (x_obs(it/obs_tintv,:) - matmul(H, x_anl(it,:))))
-          write(6,*) '  ANALYSIS (AFTER) = ', x_anl(it,1:5)
+          write(6,*) '  ANALYSIS (AFTER) = ', x_anl(it,1:5), '...'
           
           Pa = matmul((I - matmul(Kg, H)), Pf)
           write(6,*) '  ANALYSIS ERROR COVARIANCE on present step.'
@@ -355,7 +355,7 @@ program lorenz96_main
       do it = 1, kt_oneday*normal_period
         write(6,*) 'Data assim. time step: ', it
 
-        write(6,*) ' CHECK ENSEMBLE FOR UPDATE (BEFORE) on ', it-1
+        write(6,*) ' CHECK ENSEMBLE PART FOR UPDATE (BEFORE) on ', it-1
         write(6,*) x_anl_m(it-1,1,1:5)
         
         do imem = 1, mems
@@ -364,13 +364,13 @@ program lorenz96_main
 
         
         if ( mod(it, obs_tintv) == 0 .and. it /= 0) then
-          write(6,*) '  TRUTH    = ', x_true(it,1:5)
-          write(6,*) '  PREDICT  = ', x_sim(it,1:5)
-          write(6,*) '  OBSERVE  = ', x_obs(it,1:5)
+          write(6,*) '  TRUTH    = ', x_true(it,1:5), '...'
+          write(6,*) '  PREDICT  = ', x_sim(it,1:5), '...'
+          write(6,*) '  OBSERVE  = ', x_obs(it,1:5), '...'
           do ix = 1, nx
             x_anl(it, ix) = sum(x_anl_m(it,ix,1:mems))/mems
           end do
-          write(6,*) '  ANALYSIS (BEFORE) = ', x_anl(it,1:5)
+          write(6,*) '  ANALYSIS (BEFORE) = ', x_anl(it,1:5), '...'
           write(6,*) ''
           Pf = 0.0d0
           
@@ -443,9 +443,9 @@ program lorenz96_main
             do ix = 1, nx
               x_anl(it, ix) = sum(x_anl_m(it, ix, :))/mems
             end do
-            write(6,*) '  ANALYSIS (AFTER) = ', x_anl(it,1:5)
+            write(6,*) '  ANALYSIS (AFTER) = ', x_anl(it,1:5), '...'
             write(6,*) ''
-            write(6,*) ' CHECK ENSEMBLE FOR UPDATE (AFTER) on ', it 
+            write(6,*) ' CHECK ENSEMBLE PART FOR UPDATE (AFTER) on ', it 
             write(6,*) x_anl_m(it,1,1:5)
             write(6,*) ''
 

--- a/lorenz96_prm.f90
+++ b/lorenz96_prm.f90
@@ -8,7 +8,7 @@ module lorenz96_prm
   private :: none 
   
   integer, public            :: nx  ! number of grid point
-  integer, public            :: ny, nt
+  integer, public            :: ny, obs_time
   integer, public            :: obs_xintv, obs_tintv
   real(r_size), save, public :: dt
   real(r_size), save, public :: force

--- a/lorenz96_view.py
+++ b/lorenz96_view.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
   obs_xintv, obs_tintv = 1, 2
   ny = int(nx/obs_xintv)
   obs_timestep = int(timestep/obs_tintv) 
-  mems = 5000
+  mems = 15
 
   outdir = './output/lorenz96'
   da_method = 'EnKF'

--- a/lorenz96_view.py
+++ b/lorenz96_view.py
@@ -105,13 +105,15 @@ if __name__ == "__main__":
   obs_xintv, obs_tintv = 1, 2
   ny = int(nx/obs_xintv)
   obs_timestep = int(timestep/obs_tintv) 
+  mems = 5
 
   outdir = './output/lorenz96'
-  da_method = 'KF'
+  da_method = 'EnKF'
+
 
   data_true_path = outdir + '/normal_true_score_' + str(nx) + 'n.csv'
   data_sim_path = outdir + '/normal_sim_score_' + str(nx) + 'n.csv'
-  data_anl_path   = outdir + '/normal_'+ da_method + '_anl_score_' + str(nx) + 'n.csv'
+  data_anl_path   = outdir + '/normal_'+ da_method + str(mems) + 'm_anl_score_' + str(nx) + 'n.csv'
   data_obs_path  = outdir + '/normal_obs_score_' + str(nx) + '.csv'
 
   data_err_path = outdir + '/Error_matrix_' + da_method + '_' + str(nx) + 'n.csv'
@@ -121,7 +123,7 @@ if __name__ == "__main__":
   # > lorenz96 cal. score
   #---------------------------------------------------------- 
   lz = lorenz96_score()
-  err = lorenz96_errcov(data_err_path)
+  #err = lorenz96_errcov(data_err_path)
 
   #---------------------------------------------------------- 
   # +++ reading func.

--- a/lorenz96_view.py
+++ b/lorenz96_view.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
   obs_xintv, obs_tintv = 1, 2
   ny = int(nx/obs_xintv)
   obs_timestep = int(timestep/obs_tintv) 
-  mems = 5
+  mems = 5000
 
   outdir = './output/lorenz96'
   da_method = 'EnKF'

--- a/lorenz96_view.py
+++ b/lorenz96_view.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
   obs_xintv, obs_tintv = 1, 1
   ny = int(nx/obs_xintv)
   obs_timestep = int(timestep/obs_tintv)-1
-  mems = 500
+  mems = 50
 
   outdir = './output/lorenz96'
   da_method = 'EnKF'

--- a/lorenz96_view.py
+++ b/lorenz96_view.py
@@ -102,10 +102,10 @@ if __name__ == "__main__":
   timestep = stepday*4+1
   
   # OBS
-  obs_xintv, obs_tintv = 1, 2
+  obs_xintv, obs_tintv = 1, 1
   ny = int(nx/obs_xintv)
-  obs_timestep = int(timestep/obs_tintv) 
-  mems = 15
+  obs_timestep = int(timestep/obs_tintv)-1
+  mems = 500
 
   outdir = './output/lorenz96'
   da_method = 'EnKF'


### PR DESCRIPTION
#24 #31 と関連。

新たに実装した点(重要度が高い順に)
- EnKFを実装(PO法とSRF法のどちらとも)
- EKF等のリファクタリング
※行列計算には、`xt_vec(nx,1), yt_vec(ny,1)` のような一時的な行列フォーマットを
　使用した方が良いと分かった。